### PR TITLE
mesa-aco: add panvk (panfrost Vulkan) driver for armhf/arm64 build

### DIFF
--- a/mesa-aco/debian/noble/rules
+++ b/mesa-aco/debian/noble/rules
@@ -90,7 +90,7 @@ else
   # etnaviv, tegra, vc4 and v3d kernel support are only available on armhf and arm64
   ifneq (,$(filter $(DEB_HOST_ARCH), armhf arm64))
 	GALLIUM_DRIVERS += etnaviv panfrost svga tegra vc4 v3d
-	VULKAN_DRIVERS += broadcom freedreno
+	VULKAN_DRIVERS += broadcom freedreno panfrost
   endif
 
   ifneq (,$(filter $(DEB_HOST_ARCH), armhf arm64 loong64 riscv64))

--- a/mesa-aco/debian/plucky/rules
+++ b/mesa-aco/debian/plucky/rules
@@ -90,7 +90,7 @@ else
   # etnaviv, tegra, vc4 and v3d kernel support are only available on armhf and arm64
   ifneq (,$(filter $(DEB_HOST_ARCH), armhf arm64))
 	GALLIUM_DRIVERS += etnaviv panfrost svga tegra vc4 v3d
-	VULKAN_DRIVERS += broadcom freedreno
+	VULKAN_DRIVERS += broadcom freedreno panfrost
   endif
 
   ifneq (,$(filter $(DEB_HOST_ARCH), armhf arm64 loong64 riscv64))


### PR DESCRIPTION
PanVK is stable and has Vulkan 1.2 support:
https://mesamatrix.net/
https://www.phoronix.com/news/PanVK-Vulkan-1.2-Merged-Mesa

Please, enable arm64 build in your PPA and build panvk on it.